### PR TITLE
Fix issues with COMMON symbol allocation

### DIFF
--- a/src/graph/built.rs
+++ b/src/graph/built.rs
@@ -227,8 +227,9 @@ impl<'arena, 'data> BuiltLinkGraph<'arena, 'data> {
         })
         .collect::<Vec<_>>();
 
-        // Sort the symbols by size.
-        common_symbols.sort_by_key(|(_, value)| *value);
+        // Sort the symbols by descending size. Larger symbols should be
+        // allocated at the beginning to minimize padding.
+        common_symbols.sort_by_key(|(_, value)| std::cmp::Reverse(*value));
 
         let align = common_section
             .characteristics()

--- a/src/graph/edge.rs
+++ b/src/graph/edge.rs
@@ -128,9 +128,14 @@ where
     /// # Note
     /// This does not deallocate the edges since they are handled by the arena.
     pub(super) fn clear(&self) {
-        self.head.set(None);
-        self.tail.set(None);
-        self.size.set(0);
+        // Remove the next edge links in each edge.
+        while let Some(edge) = self.pop_front() {
+            edge.next_node().take();
+        }
+
+        // Post-condition asserting that pop_front() removed all of the edges
+        // correctly
+        debug_assert!(self.is_empty());
     }
 }
 

--- a/tests/bss/commons.yaml
+++ b/tests/bss/commons.yaml
@@ -4,7 +4,8 @@ header:
   Characteristics: [ IMAGE_FILE_RELOCS_STRIPPED ]
 sections: []
 symbols:
-  # This symbol should cause a .bss section to be created
+  # This symbol should cause a .bss section to be created.
+  # Since this symbol is smaller than the other common symbol, it should be placed after.
   - Name: common_symbol
     Value: 4
     SectionNumber: 0
@@ -18,7 +19,8 @@ header:
   Characteristics: [ IMAGE_FILE_RELOCS_STRIPPED ]
 sections: []
 symbols:
-  # This symbol should cause a .bss section to be created
+  # This symbol should cause a .bss section to be created.
+  # Since this symbol is the largest, it should be placed at the beginng of the section.
   - Name: other_common
     Value:           8
     SectionNumber:   0

--- a/tests/bss/commons_sorted.yaml
+++ b/tests/bss/commons_sorted.yaml
@@ -1,0 +1,83 @@
+# The symbol ordering from the start to end should be:
+# - very_large
+# - large
+# - medium
+# - larger_than_small
+# - small
+# - smaller
+# - smallerer
+# - smallest
+
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ IMAGE_FILE_RELOCS_STRIPPED ]
+sections: []
+symbols:
+  - Name:            smallest
+    Value:           1
+    SectionNumber:   0
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_EXTERNAL
+
+  - Name:            medium
+    Value:           8
+    SectionNumber:   0
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_EXTERNAL
+
+  - Name:            larger_than_small
+    Value:           5
+    SectionNumber:   0
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_EXTERNAL
+
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ IMAGE_FILE_RELOCS_STRIPPED ]
+sections: []
+symbols:
+  - Name:            smallerer
+    Value:           2
+    SectionNumber:   0
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_EXTERNAL
+
+  - Name:            large
+    Value:           16
+    SectionNumber:   0
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_EXTERNAL
+
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ IMAGE_FILE_RELOCS_STRIPPED ]
+sections: []
+symbols:
+  - Name:            small
+    Value:           4
+    SectionNumber:   0
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_EXTERNAL
+
+  - Name:            smaller
+    Value:           3
+    SectionNumber:   0
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_EXTERNAL
+
+  - Name:            very_large
+    Value:           32
+    SectionNumber:   0
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_EXTERNAL


### PR DESCRIPTION
The COMMON symbols should have been sorted by descending size not ascending size to help minimize padding.

The edge list for the COMMON section was not being cleared properly which would result in potentially stale edges
being retained.