### PR TITLE
Fix `.rdata$zzz` GCC metadata section JamCRC calculation

### DIFF
--- a/src/graph/link.rs
+++ b/src/graph/link.rs
@@ -485,7 +485,7 @@ impl<'arena, 'data> LinkGraph<'arena, 'data> {
                     if let SectionNodeData::Initialized(data) = graph_section.data() {
                         let mut h = jamcrc::Hasher::new_with_initial(!0);
                         h.update(data);
-                        checksum = !h.finalize();
+                        checksum = h.finalize();
                     }
                 }
 


### PR DESCRIPTION
The finalized value for the calculated checksum does not need to be negated because that is already handled in the jamcrc crate.

This should not cause any issues since the checksum calculation here is only used for deduplicating these sections at the very end.