### PR TITLE
Fix entrypoint symbol from the command line not being validated

### DIFF
--- a/src/bin/boflink/main.rs
+++ b/src/bin/boflink/main.rs
@@ -81,7 +81,9 @@ fn run_linker(args: &mut CliArgs) -> anyhow::Result<()> {
         }
     }
 
-    let linker = LinkerBuilder::new().library_searcher(library_searcher);
+    let linker = LinkerBuilder::new()
+        .library_searcher(library_searcher)
+        .entrypoint(std::mem::take(&mut args.entry));
 
     let linker = if let Some(target_arch) = args.machine.take() {
         linker.architecture(target_arch.into())

--- a/src/linker/builder.rs
+++ b/src/linker/builder.rs
@@ -74,6 +74,12 @@ impl<L: LibraryFind + 'static> LinkerBuilder<L> {
         self
     }
 
+    /// Set the name of the entrypoint symbol.
+    pub fn entrypoint(mut self, name: impl Into<String>) -> Self {
+        self.entrypoint = Some(name.into());
+        self
+    }
+
     /// Custom BOF API to use instead of the Beacon API.
     pub fn custom_api(mut self, api: impl Into<String>) -> Self {
         self.custom_api = Some(api.into());

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,5 +2,6 @@ mod bss;
 mod comdats;
 mod compilers;
 mod imports;
+mod misc;
 mod relocations;
 mod utils;

--- a/tests/misc/entrypoint_validation.yaml
+++ b/tests/misc/entrypoint_validation.yaml
@@ -1,0 +1,29 @@
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ IMAGE_FILE_RELOCS_STRIPPED ]
+sections:
+  - Name:            .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment:       8
+    SectionData:     0000000000000000
+    SizeOfRawData:   8
+symbols:
+  - Name:            .text
+    Value:           0
+    SectionNumber:   1
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          8
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          0
+  - Name: foo
+    Value: 0
+    SectionNumber: 1
+    SimpleType: IMAGE_SYM_TYPE_NULL
+    ComplexType: IMAGE_SYM_DTYPE_FUNCTION
+    StorageClass: IMAGE_SYM_CLASS_EXTERNAL

--- a/tests/misc/mod.rs
+++ b/tests/misc/mod.rs
@@ -1,0 +1,38 @@
+use boflink::linker::{
+    LinkerTargetArch,
+    error::{LinkError, LinkerSymbolErrorKind},
+};
+
+use crate::setup_linker;
+
+#[test]
+fn entrypoint_validation() {
+    let linker =
+        setup_linker!("entrypoint_validation.yaml", LinkerTargetArch::Amd64).entrypoint("go");
+
+    let link_error = linker
+        .build()
+        .link()
+        .expect_err("Linking should have returned an error");
+
+    match link_error {
+        LinkError::Symbol(symbol_errors) => {
+            let go_error = symbol_errors
+                .errors()
+                .iter()
+                .find(|symbol_error| symbol_error.name == "go")
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Could not find error for the 'go' symbol.\n{:#?}",
+                        symbol_errors.errors()
+                    )
+                });
+
+            assert!(
+                matches!(go_error.kind, LinkerSymbolErrorKind::Undefined(_)),
+                "Symbol error kind should be undefined.\n{go_error:#?}"
+            );
+        }
+        o => panic!("Incorrect link error variant: {o:#?}"),
+    };
+}


### PR DESCRIPTION
The passed in entrypoint symbol from the command line was not being
included as a link symbol.

This would allow BOFs to be built without first checking if there is an entrypoint definition.

The entrypoint symbol is also needed so that the linker will search for it in link libraries
if it is defined there instead of in COFF inputs.
