### PR TITLE
Fix relocations being incorrectly applied when targeting a section symbol in the same output section

### DIFF
--- a/src/graph/built.rs
+++ b/src/graph/built.rs
@@ -967,7 +967,9 @@ impl<'arena, 'data> BuiltLinkGraph<'arena, 'data> {
                         });
 
                     // Update relocations
-                    let relocated_val = if target_symbol.is_section_symbol() {
+                    let relocated_val = if target_symbol.is_section_symbol()
+                        && (section_node.name().group_name() != target_section.name().group_name())
+                    {
                         // Target symbol is a section symbol. Relocations need to
                         // be adjusted to account for the section shift.
                         let reloc_val = u32::from_le_bytes(reloc_data);

--- a/tests/relocations/same_section_symbol_flattened.yaml
+++ b/tests/relocations/same_section_symbol_flattened.yaml
@@ -1,0 +1,126 @@
+# This COFF has a function relocation in the 'go' function to the 'source2_function'
+# symbol which is defined in another COFF
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics:
+  - IMAGE_FILE_LINE_NUMS_STRIPPED
+sections:
+- Name: '.text'
+  Characteristics:
+  - IMAGE_SCN_CNT_CODE
+  - IMAGE_SCN_MEM_EXECUTE
+  - IMAGE_SCN_MEM_READ
+  Alignment: 16
+  SectionData: '554889E54883EC20E800000000904883C4205DC3909090909090909090909090'
+  SizeOfRawData: 32
+  Relocations:
+  - VirtualAddress: 9
+    SymbolName: source2_function
+    Type: IMAGE_REL_AMD64_REL32
+symbols:
+- Name: go
+  Value: 0
+  SectionNumber: 1
+  SimpleType: IMAGE_SYM_TYPE_NULL
+  ComplexType: IMAGE_SYM_DTYPE_FUNCTION
+  StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  FunctionDefinition:
+    TagIndex: 0
+    TotalSize: 0
+    PointerToLinenumber: 0
+    PointerToNextFunction: 0
+- Name: '.text'
+  Value: 0
+  SectionNumber: 1
+  SimpleType: IMAGE_SYM_TYPE_NULL
+  ComplexType: IMAGE_SYM_DTYPE_NULL
+  StorageClass: IMAGE_SYM_CLASS_STATIC
+  SectionDefinition:
+    Length: 20
+    NumberOfRelocations: 1
+    NumberOfLinenumbers: 0
+    CheckSum: 0
+    Number: 0
+    Selection: 0
+- Name: source2_function
+  Value: 0
+  SectionNumber: 0
+  SimpleType: IMAGE_SYM_TYPE_NULL
+  ComplexType: IMAGE_SYM_DTYPE_FUNCTION
+  StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+
+# This COFF has a two '.text' sections with one containing a relocation to the other.
+# There is a relocation to a section symbol that will end up in the same output section.
+# This scenario occurs if compiling with '-ffunction-sections' using GCC.
+# This relocation should be flattened.
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics:
+  - IMAGE_FILE_LINE_NUMS_STRIPPED
+sections:
+- Name: '.text'
+  Characteristics:
+  - IMAGE_SCN_CNT_CODE
+  - IMAGE_SCN_MEM_EXECUTE
+  - IMAGE_SCN_MEM_READ
+  Alignment: 16
+  SectionData: '554889E54883EC20E800000000904883C4205DC3909090909090909090909090'
+  SizeOfRawData: 32
+  Relocations:
+  - VirtualAddress: 9
+    SymbolName: '.text$other'
+    Type: IMAGE_REL_AMD64_REL32
+- Name: '.text$other'
+  Characteristics:
+  - IMAGE_SCN_CNT_CODE
+  - IMAGE_SCN_MEM_EXECUTE
+  - IMAGE_SCN_MEM_READ
+  Alignment: 16
+  SectionData: '554889E5905DC3909090909090909090'
+  SizeOfRawData: 16
+symbols:
+- Name: other
+  Value: 0
+  SectionNumber: 2
+  SimpleType: IMAGE_SYM_TYPE_NULL
+  ComplexType: IMAGE_SYM_DTYPE_FUNCTION
+  StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+  FunctionDefinition:
+    TagIndex: 0
+    TotalSize: 0
+    PointerToLinenumber: 0
+    PointerToNextFunction: 0
+- Name: source2_function
+  Value: 0
+  SectionNumber: 1
+  SimpleType: IMAGE_SYM_TYPE_NULL
+  ComplexType: IMAGE_SYM_DTYPE_FUNCTION
+  StorageClass: IMAGE_SYM_CLASS_EXTERNAL
+- Name: '.text'
+  Value: 0
+  SectionNumber: 1
+  SimpleType: IMAGE_SYM_TYPE_NULL
+  ComplexType: IMAGE_SYM_DTYPE_NULL
+  StorageClass: IMAGE_SYM_CLASS_STATIC
+  SectionDefinition:
+    Length: 20
+    NumberOfRelocations: 1
+    NumberOfLinenumbers: 0
+    CheckSum: 0
+    Number: 0
+    Selection: 0
+- Name: '.text$other'
+  Value: 0
+  SectionNumber: 2
+  SimpleType: IMAGE_SYM_TYPE_NULL
+  ComplexType: IMAGE_SYM_DTYPE_NULL
+  StorageClass: IMAGE_SYM_CLASS_STATIC
+  SectionDefinition:
+    Length: 7
+    NumberOfRelocations: 0
+    NumberOfLinenumbers: 0
+    CheckSum: 0
+    Number: 0
+    Selection: 0


### PR DESCRIPTION
In cases where `-ffunction-sections` is used when compiling with MinGW GCC, there will be relocations to section symbols which will end up in the same `.text` section.

These relocations should be treated as regular symbol relocations which are defined in the same output section rather than a relocation to a section symbol with a shifted address.
