### PR TITLE
Add support for `--gc-sections`

### DIFF
--- a/src/bin/boflink/arguments.rs
+++ b/src/bin/boflink/arguments.rs
@@ -66,6 +66,17 @@ pub struct CliArgs {
     #[arg(long)]
     pub merge_bss: bool,
 
+    /// Enable garbage collection of unused sections
+    #[arg(long)]
+    pub gc_sections: bool,
+
+    /// Ensure that the specified symbols are kept during '--gc-sections'
+    ///
+    /// Can be specified multiple times.
+    /// Accepts a comma separated list of symbols
+    #[arg(long, value_name = "symbol", value_delimiter = ',')]
+    pub keep_symbol: Vec<String>,
+
     /// Print colored output
     #[arg(long, value_name = "color", default_value_t = ColorOption::Auto)]
     pub color: ColorOption,

--- a/src/bin/boflink/arguments.rs
+++ b/src/bin/boflink/arguments.rs
@@ -77,6 +77,10 @@ pub struct CliArgs {
     #[arg(long, value_name = "symbol", value_delimiter = ',')]
     pub keep_symbol: Vec<String>,
 
+    /// Print sections discarded during '--gc-sections'
+    #[arg(long)]
+    pub print_gc_sections: bool,
+
     /// Print colored output
     #[arg(long, value_name = "color", default_value_t = ColorOption::Auto)]
     pub color: ColorOption,

--- a/src/bin/boflink/main.rs
+++ b/src/bin/boflink/main.rs
@@ -87,6 +87,7 @@ fn run_linker(args: &mut CliArgs) -> anyhow::Result<()> {
         .add_libraries(std::mem::take(&mut args.libraries))
         .merge_bss(args.merge_bss)
         .gc_sections(args.gc_sections)
+        .print_gc_sections(args.print_gc_sections)
         .add_gc_keep_symbols(std::mem::take(&mut args.keep_symbol));
 
     let linker = if let Some(target_arch) = args.machine.take() {

--- a/src/bin/boflink/main.rs
+++ b/src/bin/boflink/main.rs
@@ -83,7 +83,11 @@ fn run_linker(args: &mut CliArgs) -> anyhow::Result<()> {
 
     let linker = LinkerBuilder::new()
         .library_searcher(library_searcher)
-        .entrypoint(std::mem::take(&mut args.entry));
+        .entrypoint(std::mem::take(&mut args.entry))
+        .add_libraries(std::mem::take(&mut args.libraries))
+        .merge_bss(args.merge_bss)
+        .gc_sections(args.gc_sections)
+        .add_gc_keep_symbols(std::mem::take(&mut args.keep_symbol));
 
     let linker = if let Some(target_arch) = args.machine.take() {
         linker.architecture(target_arch.into())
@@ -103,8 +107,6 @@ fn run_linker(args: &mut CliArgs) -> anyhow::Result<()> {
         linker
     };
 
-    let linker = linker.merge_bss(args.merge_bss);
-
     let mut error_flag = false;
     let inputs = std::mem::take(&mut args.files)
         .into_iter()
@@ -123,8 +125,6 @@ fn run_linker(args: &mut CliArgs) -> anyhow::Result<()> {
     if error_flag {
         bail!(EmptyError);
     }
-
-    let linker = linker.add_libraries(std::mem::take(&mut args.libraries));
 
     let mut linker = linker.build();
 

--- a/src/graph/built.rs
+++ b/src/graph/built.rs
@@ -246,6 +246,23 @@ impl<'arena, 'data> BuiltLinkGraph<'arena, 'data> {
         section_dfs.for_each(|section| section.keep());
     }
 
+    /// Print discarded sections
+    pub fn print_discarded_sections(&self) {
+        for section in self
+            .sections
+            .values()
+            .flat_map(|sections| sections.nodes.iter())
+        {
+            if section.is_discarded() {
+                println!(
+                    "removing unused section {}:({})",
+                    section.coff(),
+                    section.name()
+                );
+            }
+        }
+    }
+
     /// Allocate space for COMMON symbols at the end of the .bss
     fn allocate_commons(&mut self) {
         // Take the value out of the OnceCell to make the function idempotent.

--- a/src/graph/cache.rs
+++ b/src/graph/cache.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use indexmap::IndexMap;
 use object::{SectionIndex, SymbolIndex};
 
 use super::{
@@ -15,6 +16,9 @@ pub struct LinkGraphCache<'arena, 'data> {
     /// Cached sections.
     sections: HashMap<SectionIndex, &'arena SectionNode<'arena, 'data>>,
 
+    /// The cached code sections.
+    code_sections: IndexMap<SectionIndex, &'arena SectionNode<'arena, 'data>>,
+
     /// Cached selection and section symbol values for COMDAT symbols.
     comdat_selections: HashMap<SectionIndex, ComdatSelection>,
 }
@@ -26,6 +30,7 @@ impl<'arena, 'data> LinkGraphCache<'arena, 'data> {
             symbols: HashMap::new(),
             sections: HashMap::new(),
             comdat_selections: HashMap::new(),
+            code_sections: IndexMap::new(),
         }
     }
 
@@ -34,6 +39,7 @@ impl<'arena, 'data> LinkGraphCache<'arena, 'data> {
         Self {
             symbols: HashMap::with_capacity(symbols),
             sections: HashMap::with_capacity(sections),
+            code_sections: IndexMap::new(),
             comdat_selections: HashMap::new(),
         }
     }
@@ -43,6 +49,7 @@ impl<'arena, 'data> LinkGraphCache<'arena, 'data> {
         self.symbols.clear();
         self.sections.clear();
         self.comdat_selections.clear();
+        self.code_sections.clear();
     }
 
     #[inline]
@@ -80,6 +87,15 @@ impl<'arena, 'data> LinkGraphCache<'arena, 'data> {
     }
 
     #[inline]
+    pub fn insert_code_section(
+        &mut self,
+        idx: SectionIndex,
+        section: &'arena SectionNode<'arena, 'data>,
+    ) {
+        let _ = self.code_sections.insert(idx, section);
+    }
+
+    #[inline]
     pub fn get_symbol(&self, idx: SymbolIndex) -> Option<&'arena SymbolNode<'arena, 'data>> {
         self.symbols.get(&idx).copied()
     }
@@ -92,5 +108,10 @@ impl<'arena, 'data> LinkGraphCache<'arena, 'data> {
     #[inline]
     pub fn get_comdat_selection(&self, idx: SectionIndex) -> Option<ComdatSelection> {
         self.comdat_selections.get(&idx).copied()
+    }
+
+    #[inline]
+    pub fn iter_code_sections(&self) -> impl Iterator<Item = &'arena SectionNode<'arena, 'data>> {
+        self.code_sections.values().copied()
     }
 }

--- a/src/linker/builder.rs
+++ b/src/linker/builder.rs
@@ -42,6 +42,9 @@ pub struct LinkerBuilder<L: LibraryFind + 'static> {
 
     /// Keep the specified symbols during GC sections.
     pub(super) gc_keep_symbols: IndexSet<String>,
+
+    /// Print sections discarded during GC sections.
+    pub(super) print_gc_sections: bool,
 }
 
 impl<L: LibraryFind + 'static> LinkerBuilder<L> {
@@ -58,6 +61,7 @@ impl<L: LibraryFind + 'static> LinkerBuilder<L> {
             link_graph_output: None,
             gc_sections: false,
             gc_keep_symbols: Default::default(),
+            print_gc_sections: false,
         }
     }
 
@@ -103,6 +107,12 @@ impl<L: LibraryFind + 'static> LinkerBuilder<L> {
     /// Enable GC sections.
     pub fn gc_sections(mut self, val: bool) -> Self {
         self.gc_sections = val;
+        self
+    }
+
+    /// Print sections discarded during GC sections.
+    pub fn print_gc_sections(mut self, val: bool) -> Self {
+        self.print_gc_sections = val;
         self
     }
 

--- a/src/linker/builder.rs
+++ b/src/linker/builder.rs
@@ -36,6 +36,12 @@ pub struct LinkerBuilder<L: LibraryFind + 'static> {
 
     /// Output path for dumping the link graph.
     pub(super) link_graph_output: Option<PathBuf>,
+
+    /// Perform GC sections.
+    pub(super) gc_sections: bool,
+
+    /// Keep the specified symbols during GC sections.
+    pub(super) gc_keep_symbols: IndexSet<String>,
 }
 
 impl<L: LibraryFind + 'static> LinkerBuilder<L> {
@@ -50,6 +56,8 @@ impl<L: LibraryFind + 'static> LinkerBuilder<L> {
             merge_bss: false,
             library_searcher: None,
             link_graph_output: None,
+            gc_sections: false,
+            gc_keep_symbols: Default::default(),
         }
     }
 
@@ -92,6 +100,12 @@ impl<L: LibraryFind + 'static> LinkerBuilder<L> {
         self
     }
 
+    /// Enable GC sections.
+    pub fn gc_sections(mut self, val: bool) -> Self {
+        self.gc_sections = val;
+        self
+    }
+
     /// Add an input file to the linker.
     pub fn add_input(mut self, input: PathedItem<PathBuf, Vec<u8>>) -> Self {
         self.inputs.push(input);
@@ -116,6 +130,22 @@ impl<L: LibraryFind + 'static> LinkerBuilder<L> {
     /// Add a set of link libraries to the linker.
     pub fn add_libraries<S: Into<String>, I: IntoIterator<Item = S>>(mut self, names: I) -> Self {
         self.libraries.extend(names.into_iter().map(Into::into));
+        self
+    }
+
+    /// Add the specified symbol to keep during GC sections.
+    pub fn add_gc_keep_symbol(mut self, symbol: impl Into<String>) -> Self {
+        self.gc_keep_symbols.insert(symbol.into());
+        self
+    }
+
+    /// Adds the list of symbols to keep during GC sections.
+    pub fn add_gc_keep_symbols<S: Into<String>, I: IntoIterator<Item = S>>(
+        mut self,
+        symbols: I,
+    ) -> Self {
+        self.gc_keep_symbols
+            .extend(symbols.into_iter().map(Into::into));
         self
     }
 

--- a/src/linker/configured.rs
+++ b/src/linker/configured.rs
@@ -53,6 +53,9 @@ pub struct ConfiguredLinker<L: LibraryFind, Api: ApiInit> {
     /// GC roots.
     gc_roots: IndexSet<String>,
 
+    /// Print GC sections discarded.
+    print_gc_sections: bool,
+
     /// Output path for dumping the link graph.
     link_graph_output: Option<PathBuf>,
 }
@@ -79,6 +82,7 @@ impl<L: LibraryFind, Api: ApiInit> ConfiguredLinker<L, Api> {
             link_graph_output: builder.link_graph_output,
             gc_sections: builder.gc_sections,
             gc_roots: builder.gc_keep_symbols,
+            print_gc_sections: builder.print_gc_sections,
         }
     }
 }
@@ -472,6 +476,10 @@ impl<L: LibraryFind, A: ApiInit> LinkImpl for ConfiguredLinker<L, A> {
 
         if self.gc_sections {
             graph.gc_sections(self.entrypoint.iter().chain(self.gc_roots.iter()));
+
+            if self.print_gc_sections {
+                graph.print_discarded_sections();
+            }
         }
 
         if self.merge_bss {


### PR DESCRIPTION
Adds garbage collection support for removing unreferenced sections.
- Includes the `--gc-sections` flag for performing section garbage collection.
- Adds `--keep-symbol` flag for preventing certain unreferenced symbols from being discarded.
- Includes `--print-gc-section` flag for printing out what sections get discarded.