### PR TITLE
Add '--no-merge-groups' flag

### DIFF
--- a/src/bin/boflink/arguments.rs
+++ b/src/bin/boflink/arguments.rs
@@ -66,6 +66,10 @@ pub struct CliArgs {
     #[arg(long)]
     pub merge_bss: bool,
 
+    /// Do not merge grouped sections
+    #[arg(long, default_value = "false")]
+    pub no_merge_groups: bool,
+
     /// Enable garbage collection of unused sections
     #[arg(long)]
     pub gc_sections: bool,

--- a/src/bin/boflink/main.rs
+++ b/src/bin/boflink/main.rs
@@ -88,7 +88,8 @@ fn run_linker(args: &mut CliArgs) -> anyhow::Result<()> {
         .merge_bss(args.merge_bss)
         .gc_sections(args.gc_sections)
         .print_gc_sections(args.print_gc_sections)
-        .add_gc_keep_symbols(std::mem::take(&mut args.keep_symbol));
+        .add_gc_keep_symbols(std::mem::take(&mut args.keep_symbol))
+        .merge_grouped_sections(!args.no_merge_groups);
 
     let linker = if let Some(target_arch) = args.machine.take() {
         linker.architecture(target_arch.into())

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -3,6 +3,7 @@ mod cache;
 pub mod edge;
 mod link;
 pub mod node;
+mod output;
 mod spec;
 
 pub use built::*;

--- a/src/graph/node/symbol.rs
+++ b/src/graph/node/symbol.rs
@@ -295,7 +295,7 @@ impl std::fmt::Debug for SymbolNode<'_, '_> {
 }
 
 /// A symbol name.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SymbolName<'data>(&'data str);
 
 impl<'data> SymbolName<'data> {
@@ -310,11 +310,16 @@ impl<'data> SymbolName<'data> {
         SymbolNameDemangler(self)
     }
 
-    /// Returns the symbol name but without the `__declspeci(dllimport)` prefix
+    /// Returns the symbol name but without the `__declspec(dllimport)` prefix
     /// if it exists.
-    #[inline]
     pub fn strip_dllimport(&self) -> Option<&'data str> {
         self.0.strip_prefix("__imp_")
+    }
+
+    /// Returns `true` if the symbol name contains the `__declspec(dllimport)`
+    /// prefix
+    pub fn is_dllimport(&self) -> bool {
+        self.0.starts_with("__imp_")
     }
 }
 
@@ -336,7 +341,7 @@ pub struct SymbolNameDemangler<'a, 'data>(&'a SymbolName<'data>);
 
 impl std::fmt::Display for SymbolNameDemangler<'_, '_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(unprefixed) = self.0.0.strip_prefix("__imp_") {
+        if let Some(unprefixed) = self.0.strip_dllimport() {
             write!(f, "__declspec(dllimport) {unprefixed}")
         } else {
             write!(f, "{}", self.0.0)

--- a/src/graph/output.rs
+++ b/src/graph/output.rs
@@ -1,0 +1,660 @@
+use std::{cell::OnceCell, collections::BTreeMap};
+
+use indexmap::IndexMap;
+use log::debug;
+use object::{
+    pe::{
+        IMAGE_FILE_LINE_NUMS_STRIPPED, IMAGE_SYM_CLASS_EXTERNAL, IMAGE_SYM_CLASS_STATIC,
+        IMAGE_SYM_TYPE_NULL,
+    },
+    write::coff::{Relocation, Writer},
+};
+
+use crate::linker::LinkerTargetArch;
+
+use super::{
+    LinkGraphArena, LinkGraphLinkError,
+    node::{
+        LibraryNode, SectionName, SectionNode, SectionNodeCharacteristics, SectionNodeData,
+        SymbolNodeType,
+    },
+};
+
+/// An output section for the [`OutputGraph`].
+pub struct OutputSection<'arena, 'data> {
+    /// The name of the output section
+    pub name: SectionName<'arena>,
+
+    /// The section characteristics
+    pub characteristics: SectionNodeCharacteristics,
+
+    /// The name of the output section in the COFF
+    output_name: OnceCell<object::write::coff::Name>,
+
+    /// The size of the data
+    size_of_raw_data: u32,
+
+    /// The pointer to the section data
+    pointer_to_raw_data: u32,
+
+    /// The number of relocations
+    number_of_relocations: u32,
+
+    /// The pointer to the relocation data
+    pointer_to_relocations: u32,
+
+    /// The list of nodes in this output section.
+    pub nodes: Vec<&'arena SectionNode<'arena, 'data>>,
+}
+
+impl<'arena, 'data> OutputSection<'arena, 'data> {
+    pub fn new(
+        name: impl Into<SectionName<'arena>>,
+        characteristics: SectionNodeCharacteristics,
+        nodes: Vec<&'arena SectionNode<'arena, 'data>>,
+    ) -> OutputSection<'arena, 'data> {
+        let mut characteristics = characteristics.zero_align();
+        characteristics.remove(
+            SectionNodeCharacteristics::LnkComdat | SectionNodeCharacteristics::LnkNRelocOvfl,
+        );
+        Self {
+            name: name.into(),
+            characteristics,
+            output_name: OnceCell::new(),
+            size_of_raw_data: 0,
+            pointer_to_raw_data: 0,
+            number_of_relocations: 0,
+            pointer_to_relocations: 0,
+            nodes,
+        }
+    }
+}
+
+/// Graph for building the final COFF.
+///
+/// This contains an additional output map which maps the input sections from
+/// the built link graph to the output sections.
+pub struct OutputGraph<'arena, 'data> {
+    /// Target architecture
+    machine: LinkerTargetArch,
+
+    /// The list of output sections.
+    output_sections: Vec<OutputSection<'arena, 'data>>,
+
+    /// The API library node
+    api_node: Option<&'arena LibraryNode<'arena, 'data>>,
+
+    /// The library nodes
+    library_nodes: IndexMap<&'data str, &'arena LibraryNode<'arena, 'data>>,
+
+    /// Graph arena allocator.
+    arena: &'arena LinkGraphArena,
+}
+
+impl<'arena, 'data> OutputGraph<'arena, 'data> {
+    pub fn new(
+        machine: LinkerTargetArch,
+        output_sections: Vec<OutputSection<'arena, 'data>>,
+        api_node: Option<&'arena LibraryNode<'arena, 'data>>,
+        library_nodes: IndexMap<&'data str, &'arena LibraryNode<'arena, 'data>>,
+        arena: &'arena LinkGraphArena,
+    ) -> OutputGraph<'arena, 'data> {
+        Self {
+            machine,
+            output_sections,
+            api_node,
+            library_nodes,
+            arena,
+        }
+    }
+
+    /// Builds the output COFF
+    pub fn build_output(mut self) -> Result<Vec<u8>, LinkGraphLinkError> {
+        let mut built_coff = Vec::new();
+        let mut coff_writer = Writer::new(&mut built_coff);
+
+        coff_writer.reserve_file_header();
+
+        // Reserve section headers
+        coff_writer.reserve_section_headers(self.output_sections.len().try_into().unwrap());
+
+        for output_section in self.output_sections.iter_mut() {
+            let mut section_alignment = 0u32;
+
+            output_section
+                .output_name
+                .set(coff_writer.add_name(output_section.name.as_str().as_bytes()))
+                .unwrap_or_else(|_| unreachable!());
+
+            // Assign virtual addresses to each section
+            for node in &output_section.nodes {
+                if let Some(align) = node.characteristics().alignment() {
+                    let align = align as u32;
+                    output_section.size_of_raw_data =
+                        output_section.size_of_raw_data.next_multiple_of(align);
+                    section_alignment = section_alignment.max(align);
+                }
+
+                debug!(
+                    "{}: mapping section '{}' to '{}' at address {:#x} with size {:#x}",
+                    node.coff(),
+                    node.name(),
+                    output_section.name,
+                    output_section.size_of_raw_data,
+                    node.data().len(),
+                );
+
+                node.assign_virtual_address(output_section.size_of_raw_data);
+                output_section.size_of_raw_data += node.data().len() as u32;
+            }
+
+            // Set the alignment needed for the output section
+            output_section
+                .characteristics
+                .set_alignment(section_alignment);
+        }
+
+        // Reserve section data
+        for section in self.output_sections.iter_mut() {
+            if !section
+                .characteristics
+                .contains(SectionNodeCharacteristics::CntUninitializedData)
+                && section.size_of_raw_data > 0
+            {
+                section.pointer_to_raw_data =
+                    coff_writer.reserve_section(section.size_of_raw_data as usize);
+            }
+        }
+
+        // Reserve relocations skipping relocations to the same output section
+        for output_section in self.output_sections.iter_mut() {
+            let mut reloc_count = 0usize;
+
+            for section_node in &output_section.nodes {
+                for reloc in section_node.relocations() {
+                    let symbol = reloc.target();
+
+                    if let Some(definition) = symbol
+                        .definitions()
+                        .iter()
+                        .find(|definition| !definition.target().is_discarded())
+                    {
+                        let target_section = definition.target();
+
+                        if output_section
+                            .nodes
+                            .iter()
+                            .any(|section| std::ptr::eq(*section, target_section))
+                        {
+                            continue;
+                        }
+                    } else if symbol.imports().is_empty() {
+                        // Symbol has no imports and all definitions are in
+                        // discarded sections. Return an error.
+
+                        let coff_name = section_node.coff().to_string();
+
+                        let symbol_defs = BTreeMap::from_iter(
+                            section_node.definitions().iter().filter_map(|definition| {
+                                let ref_symbol = definition.source();
+                                if ref_symbol.is_section_symbol() || ref_symbol.is_label() {
+                                    None
+                                } else {
+                                    Some((definition.weight().address(), ref_symbol.name()))
+                                }
+                            }),
+                        );
+
+                        if let Some(reference_symbol) =
+                            symbol_defs.range(0..=reloc.weight().address()).next_back()
+                        {
+                            return Err(LinkGraphLinkError::DiscardedSection {
+                                coff_name,
+                                reference: reference_symbol.1.demangle().to_string(),
+                                symbol: symbol.name().demangle().to_string(),
+                            });
+                        } else {
+                            return Err(LinkGraphLinkError::DiscardedSection {
+                                coff_name,
+                                reference: format!(
+                                    "{}+{:#x}",
+                                    section_node.name(),
+                                    reloc.weight().address()
+                                ),
+                                symbol: symbol.name().demangle().to_string(),
+                            });
+                        }
+                    }
+
+                    reloc_count += 1;
+                }
+            }
+
+            output_section.number_of_relocations = reloc_count.try_into().unwrap();
+            output_section.pointer_to_relocations = coff_writer.reserve_relocations(reloc_count);
+        }
+
+        // Reserve symbols defined in sections
+        for section in self.output_sections.iter() {
+            // Reserve the section symbol
+            let section_symbol_index = coff_writer.reserve_symbol_index();
+            let _ = coff_writer.reserve_aux_section();
+
+            for section_node in &section.nodes {
+                // Assign table indicies to defined symbols
+                for definition in section_node.definitions() {
+                    let symbol = definition.source();
+
+                    // Section symbol already reserved. Set the index to the
+                    // existing one
+                    if symbol.is_section_symbol() {
+                        symbol
+                            .assign_table_index(section_symbol_index)
+                            .unwrap_or_else(|v| {
+                                panic!(
+                                    "symbol {} already assigned to symbol table index {v}",
+                                    symbol.name().demangle()
+                                )
+                            });
+                    } else if symbol.is_label() {
+                        // Associate labels with the section symbol
+                        symbol
+                            .assign_table_index(section_symbol_index)
+                            .unwrap_or_else(|v| {
+                                panic!(
+                                    "symbol {} already assigned to symbol table index {v}",
+                                    symbol.name().demangle()
+                                )
+                            });
+                    } else {
+                        let _ = symbol.output_name().get_or_init(|| {
+                            coff_writer.add_name(symbol.name().as_str().as_bytes())
+                        });
+
+                        // Reserve an index for this symbol
+                        symbol
+                            .assign_table_index(coff_writer.reserve_symbol_index())
+                            .unwrap_or_else(|v| {
+                                panic!(
+                                    "symbol {} already assigned to symbol table index {v}",
+                                    symbol.name().demangle()
+                                )
+                            });
+                    }
+                }
+            }
+        }
+
+        // Reserve API imported symbols
+        if let Some(api_node) = self.api_node {
+            for import in api_node.imports() {
+                let symbol = import.source();
+
+                let _ = symbol
+                    .output_name()
+                    .get_or_init(|| coff_writer.add_name(symbol.name().as_str().as_bytes()));
+
+                symbol
+                    .assign_table_index(coff_writer.reserve_symbol_index())
+                    .unwrap_or_else(|v| {
+                        panic!(
+                            "symbol {} already assigned to symbol table index {v}",
+                            symbol.name().demangle()
+                        )
+                    });
+            }
+        }
+
+        // Reserve library imported symbols
+        for library in self.library_nodes.values() {
+            for import in library.imports() {
+                let symbol = import.source();
+
+                let name = self.arena.alloc_str(&format!(
+                    "__imp_{}${}",
+                    library.name().trim_dll_suffix(),
+                    import.weight().import_name()
+                ));
+
+                let _ = symbol
+                    .output_name()
+                    .get_or_init(|| coff_writer.add_name(name.as_bytes()));
+
+                symbol
+                    .assign_table_index(coff_writer.reserve_symbol_index())
+                    .unwrap_or_else(|v| {
+                        panic!(
+                            "symbol {} already assigned to symbol table index {v}",
+                            symbol.name().demangle()
+                        )
+                    });
+            }
+        }
+
+        // Finish reserving COFF data
+        coff_writer.reserve_symtab_strtab();
+
+        // Write out the file header
+        coff_writer
+            .write_file_header(object::write::coff::FileHeader {
+                machine: self.machine.into(),
+                time_date_stamp: 0,
+                characteristics: IMAGE_FILE_LINE_NUMS_STRIPPED,
+            })
+            .unwrap();
+
+        // Write out the section headers
+        for output_section in &self.output_sections {
+            coff_writer.write_section_header(object::write::coff::SectionHeader {
+                name: *output_section.output_name.get().unwrap_or_else(|| {
+                    panic!(
+                        "Output section name for {} never reserved in COFF",
+                        output_section.name
+                    )
+                }),
+                size_of_raw_data: output_section.size_of_raw_data,
+                pointer_to_raw_data: output_section.pointer_to_raw_data,
+                characteristics: output_section.characteristics.bits(),
+                pointer_to_relocations: output_section.pointer_to_relocations,
+                number_of_relocations: output_section.number_of_relocations,
+                ..Default::default()
+            });
+        }
+
+        // Write out the section data
+        for section in &self.output_sections {
+            if section.size_of_raw_data > 0
+                && !section
+                    .characteristics
+                    .contains(SectionNodeCharacteristics::CntUninitializedData)
+            {
+                coff_writer.write_section_align();
+
+                let alignment_byte = if section
+                    .characteristics
+                    .contains(SectionNodeCharacteristics::CntCode)
+                {
+                    0x90u8
+                } else {
+                    0x00u8
+                };
+
+                let mut data_written = 0;
+                let mut alignment_buffer = vec![alignment_byte; 16];
+
+                for node in section.nodes.iter() {
+                    // Write alignment padding
+                    let needed = node.virtual_address() - data_written;
+                    if needed > 0 {
+                        alignment_buffer.resize(needed as usize, alignment_byte);
+                        coff_writer.write(&alignment_buffer);
+                        data_written += needed;
+                    }
+
+                    let section_data = match node.data() {
+                        SectionNodeData::Initialized(data) => data,
+                        SectionNodeData::Uninitialized(size) => {
+                            // This node contains uninitialized data but the
+                            // output section should be initialized.
+                            // Write out padding bytes to satisfy the size
+                            // requested
+                            alignment_buffer.resize(size as usize, alignment_byte);
+                            alignment_buffer.as_slice()
+                        }
+                    };
+
+                    coff_writer.write(section_data);
+                    data_written += section_data.len() as u32;
+                }
+            }
+        }
+
+        // Write out the relocations skipping relocations to the same section
+        for output_section in &self.output_sections {
+            for section_node in &output_section.nodes {
+                for reloc in section_node.relocations() {
+                    let target_symbol = reloc.target();
+
+                    if let Some(symbol_definition) = target_symbol
+                        .definitions()
+                        .iter()
+                        .find(|definition| !definition.target().is_discarded())
+                    {
+                        let target_section = symbol_definition.target();
+
+                        if output_section
+                            .nodes
+                            .iter()
+                            .any(|section| std::ptr::eq(*section, target_section))
+                        {
+                            continue;
+                        }
+                    }
+
+                    coff_writer.write_relocation(Relocation {
+                        virtual_address: section_node.virtual_address() + reloc.weight().address(),
+                        symbol: target_symbol.table_index().unwrap_or_else(|| {
+                            panic!(
+                                "symbol {} was never assigned a symbol table index",
+                                target_symbol.name().demangle()
+                            )
+                        }),
+                        typ: reloc.weight().typ(),
+                    });
+                }
+            }
+        }
+
+        // Write out symbols defined in sections
+        for (section_index, output_section) in self.output_sections.iter().enumerate() {
+            // Write the section symbol
+            coff_writer.write_symbol(object::write::coff::Symbol {
+                name: *output_section.output_name.get().unwrap_or_else(|| {
+                    panic!(
+                        "Output section name {} never reserved in COFF",
+                        output_section.name
+                    )
+                }),
+                value: 0,
+                section_number: (section_index + 1).try_into().unwrap(),
+                typ: IMAGE_SYM_TYPE_NULL,
+                storage_class: IMAGE_SYM_CLASS_STATIC,
+                number_of_aux_symbols: 1,
+            });
+
+            coff_writer.write_aux_section(object::write::coff::AuxSymbolSection {
+                length: output_section.size_of_raw_data,
+                number_of_relocations: output_section.number_of_relocations,
+                number_of_linenumbers: 0,
+                // The object crate will calculate the checksum
+                check_sum: 0,
+                number: (section_index + 1).try_into().unwrap(),
+                selection: 0,
+            });
+
+            for section_node in &output_section.nodes {
+                for definition in section_node.definitions() {
+                    let symbol = definition.source();
+
+                    // Skip labels and section symbols
+                    if !symbol.is_section_symbol() && !symbol.is_label() {
+                        coff_writer.write_symbol(object::write::coff::Symbol {
+                            name: symbol.output_name().get().copied().unwrap_or_else(|| {
+                                panic!(
+                                    "symbol {} never had the name reserved in the output COFF",
+                                    symbol.name().demangle()
+                                )
+                            }),
+                            value: definition.weight().address() + section_node.virtual_address(),
+                            section_number: (section_index + 1).try_into().unwrap(),
+                            typ: match symbol.typ() {
+                                SymbolNodeType::Value(typ) => typ,
+                                _ => unreachable!(),
+                            },
+                            storage_class: symbol.storage_class().into(),
+                            number_of_aux_symbols: 0,
+                        });
+                    }
+                }
+            }
+        }
+
+        // Write out API imported symbols
+        if let Some(api_node) = self.api_node {
+            for import in api_node.imports() {
+                let symbol = import.source();
+                coff_writer.write_symbol(object::write::coff::Symbol {
+                    name: symbol.output_name().get().copied().unwrap_or_else(|| {
+                        panic!(
+                            "symbol {} never had the name reserved in the output COFF",
+                            symbol.name().demangle()
+                        )
+                    }),
+                    value: 0,
+                    section_number: 0,
+                    typ: 0,
+                    storage_class: IMAGE_SYM_CLASS_EXTERNAL,
+                    number_of_aux_symbols: 0,
+                });
+            }
+        }
+
+        // Write out library imported symbols
+        for library in self.library_nodes.values() {
+            for import in library.imports() {
+                let symbol = import.source();
+                coff_writer.write_symbol(object::write::coff::Symbol {
+                    name: symbol.output_name().get().copied().unwrap_or_else(|| {
+                        panic!(
+                            "symbol {} never had the name reserved in the output COFF",
+                            symbol.name().demangle()
+                        )
+                    }),
+                    value: 0,
+                    section_number: 0,
+                    typ: 0,
+                    storage_class: IMAGE_SYM_CLASS_EXTERNAL,
+                    number_of_aux_symbols: 0,
+                });
+            }
+        }
+
+        // Finish writing the COFF
+        coff_writer.write_strtab();
+
+        // Fixup relocations
+        for output_section in &self.output_sections {
+            let section_data_base = output_section.pointer_to_raw_data as usize;
+
+            for section_node in &output_section.nodes {
+                let section_data_ptr = section_data_base + section_node.virtual_address() as usize;
+
+                let section_data =
+                    &mut built_coff[section_data_ptr..section_data_ptr + section_node.data().len()];
+
+                for reloc_edge in section_node.relocations() {
+                    let target_symbol = reloc_edge.target();
+
+                    let symbol_definition = match target_symbol
+                        .definitions()
+                        .iter()
+                        .find(|definition| !definition.target().is_discarded())
+                    {
+                        Some(definition) => definition,
+                        None => continue,
+                    };
+
+                    let target_section = symbol_definition.target();
+                    let reloc = reloc_edge.weight();
+
+                    // Return an error if the relocation is out of bounds.
+                    if reloc.virtual_address + 4 > section_node.data().len() as u32 {
+                        return Err(LinkGraphLinkError::RelocationBounds {
+                            coff_name: section_node.coff().to_string(),
+                            section: section_node.name().to_string(),
+                            address: reloc.virtual_address,
+                            size: section_node.data().len() as u32,
+                        });
+                    }
+
+                    // The relocation bounds check above checks the relocation
+                    // in the graph. This indexes into the built COFF after
+                    // everything is merged. The slice index should always
+                    // be in bounds but if it is not, there is some logic
+                    // error above. Panic with a verbose error message if that
+                    // is the case.
+
+                    let reloc_data: [u8; 4] = section_data
+                        .get(reloc.address() as usize..reloc.address() as usize + 4)
+                        .map(|data| data.try_into().unwrap_or_else(|_| unreachable!()))
+                        .unwrap_or_else(|| {
+                            unreachable!(
+                                "relocation in section '{}' is out of bounds",
+                                section_node.name()
+                            )
+                        });
+
+                    // Update relocations
+                    let relocated_val = if target_symbol.is_section_symbol()
+                        && !output_section
+                            .nodes
+                            .iter()
+                            .any(|section| std::ptr::eq(*section, target_section))
+                    {
+                        // Target symbol is a section symbol. Relocations need to
+                        // be adjusted to account for the section shift.
+                        let reloc_val = u32::from_le_bytes(reloc_data);
+
+                        reloc_val
+                            .checked_add(target_section.virtual_address())
+                            .ok_or_else(|| LinkGraphLinkError::RelocationOverflow {
+                                coff_name: section_node.coff().to_string(),
+                                section: section_node.name().to_string(),
+                                address: reloc.address(),
+                            })?
+                    } else if section_node.name().group_name() == target_section.name().group_name()
+                    {
+                        // Relocation targets a symbol defined in the same section.
+                        // Apply the relocation to the symbol address.
+
+                        let reloc_addr = reloc.address() + section_node.virtual_address();
+                        let symbol_addr =
+                            symbol_definition.weight().address() + target_section.virtual_address();
+
+                        let reloc_val = u32::from_be_bytes(reloc_data);
+                        let delta = symbol_addr.wrapping_sub(reloc_addr + 4);
+                        reloc_val.wrapping_add(delta)
+                    } else if target_symbol.is_label() {
+                        // Old relocation target symbol is a label. The current
+                        // relocation points to the section symbol and the label
+                        // was discarded.
+                        // Handle this like a section symbol relocation but
+                        // shift it to point to the label's virtual address in
+                        // the section.
+                        let reloc_val = u32::from_le_bytes(reloc_data);
+                        let symbol_addr = symbol_definition.weight().address();
+
+                        reloc_val
+                            .checked_add(target_section.virtual_address())
+                            .and_then(|reloc_val| reloc_val.checked_add(symbol_addr))
+                            .ok_or_else(|| LinkGraphLinkError::RelocationOverflow {
+                                coff_name: section_node.coff().to_string(),
+                                section: section_node.name().to_string(),
+                                address: reloc.address(),
+                            })?
+                    } else {
+                        // Relocation target is symbolic and does not need
+                        // updating
+                        continue;
+                    };
+
+                    // Write the new reloc
+                    section_data[reloc.address() as usize..reloc.address() as usize + 4]
+                        .copy_from_slice(&relocated_val.to_le_bytes());
+                }
+            }
+        }
+
+        Ok(built_coff)
+    }
+}

--- a/src/linker/builder.rs
+++ b/src/linker/builder.rs
@@ -31,6 +31,9 @@ pub struct LinkerBuilder<L: LibraryFind + 'static> {
     /// Whether to merge the .bss section with the .data section.
     pub(super) merge_bss: bool,
 
+    /// Merge grouped sections.
+    pub(super) merge_grouped_sections: bool,
+
     /// Searcher for finding link libraries.
     pub(super) library_searcher: Option<L>,
 
@@ -57,6 +60,7 @@ impl<L: LibraryFind + 'static> LinkerBuilder<L> {
             entrypoint: Default::default(),
             custom_api: Default::default(),
             merge_bss: false,
+            merge_grouped_sections: false,
             library_searcher: None,
             link_graph_output: None,
             gc_sections: false,
@@ -83,6 +87,12 @@ impl<L: LibraryFind + 'static> LinkerBuilder<L> {
     /// Merge the .bss section with the .data section.
     pub fn merge_bss(mut self, val: bool) -> Self {
         self.merge_bss = val;
+        self
+    }
+
+    /// Merge grouped sections.
+    pub fn merge_grouped_sections(mut self, val: bool) -> Self {
+        self.merge_grouped_sections = val;
         self
     }
 

--- a/src/linker/configured.rs
+++ b/src/linker/configured.rs
@@ -53,6 +53,9 @@ pub struct ConfiguredLinker<L: LibraryFind, Api: ApiInit> {
     /// GC roots.
     gc_roots: IndexSet<String>,
 
+    /// Merge grouped sections.
+    merge_grouped_sections: bool,
+
     /// Print GC sections discarded.
     print_gc_sections: bool,
 
@@ -79,6 +82,7 @@ impl<L: LibraryFind, Api: ApiInit> ConfiguredLinker<L, Api> {
             library_searcher,
             entrypoint: builder.entrypoint,
             merge_bss: builder.merge_bss,
+            merge_grouped_sections: builder.merge_grouped_sections,
             link_graph_output: builder.link_graph_output,
             gc_sections: builder.gc_sections,
             gc_roots: builder.gc_keep_symbols,
@@ -486,6 +490,10 @@ impl<L: LibraryFind, A: ApiInit> LinkImpl for ConfiguredLinker<L, A> {
             graph.merge_bss();
         }
 
-        Ok(graph.link_merge_groups()?)
+        if self.merge_grouped_sections {
+            Ok(graph.link_merge_groups()?)
+        } else {
+            Ok(graph.link()?)
+        }
     }
 }

--- a/src/linker/configured.rs
+++ b/src/linker/configured.rs
@@ -486,6 +486,6 @@ impl<L: LibraryFind, A: ApiInit> LinkImpl for ConfiguredLinker<L, A> {
             graph.merge_bss();
         }
 
-        Ok(graph.link()?)
+        Ok(graph.link_merge_groups()?)
     }
 }

--- a/tests/comdats/any.yaml
+++ b/tests/comdats/any.yaml
@@ -13,7 +13,7 @@ sections:
         SymbolName:      '??_C@_0M@KPLPPDAC@Hello?5World?$AA@'
         Type:            IMAGE_REL_AMD64_REL32
       - VirtualAddress:  14
-        SymbolName:      BeaconPrintf
+        SymbolName:      __imp_BeaconPrintf
         Type:            IMAGE_REL_AMD64_REL32
   - Name:            .rdata
     Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_LNK_COMDAT, IMAGE_SCN_MEM_READ ]
@@ -58,7 +58,7 @@ symbols:
     SimpleType:      IMAGE_SYM_TYPE_NULL
     ComplexType:     IMAGE_SYM_DTYPE_FUNCTION
     StorageClass:    IMAGE_SYM_CLASS_EXTERNAL
-  - Name:            BeaconPrintf
+  - Name:            __imp_BeaconPrintf
     Value:           0
     SectionNumber:   0
     SimpleType:      IMAGE_SYM_TYPE_NULL

--- a/tests/comdats/mod.rs
+++ b/tests/comdats/mod.rs
@@ -52,7 +52,7 @@ fn associative() {
 
     assert!(
         root_data.iter().all(|b| *b == 0),
-        ".root section data should be all zeros"
+        ".root section data should be all zeros {root_data:x?}"
     );
 
     let assoc_section = coff

--- a/tests/misc/mod.rs
+++ b/tests/misc/mod.rs
@@ -1,4 +1,12 @@
 use boflink::linker::LinkerTargetArch;
+use object::{
+    Object,
+    coff::CoffFile,
+    pe::{
+        IMAGE_SCN_CNT_CODE, IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_EXECUTE,
+        IMAGE_SCN_MEM_READ, IMAGE_SCN_MEM_WRITE,
+    },
+};
 
 use crate::setup_linker;
 
@@ -11,4 +19,59 @@ fn externals_relaxation() {
         .build()
         .link()
         .expect("Could not link files");
+}
+
+#[test]
+fn no_merge_groups() {
+    let linked = setup_linker!("no_merge_groups.yaml", LinkerTargetArch::Amd64)
+        .merge_grouped_sections(false)
+        .build()
+        .link()
+        .expect("Could not link inputs");
+
+    let coff: CoffFile = CoffFile::parse(linked.as_slice()).expect("Could not parse linked output");
+
+    let test_sections: &[(&str, u32)] = &[
+        (
+            ".text$a",
+            IMAGE_SCN_CNT_CODE | IMAGE_SCN_MEM_EXECUTE | IMAGE_SCN_MEM_READ,
+        ),
+        (
+            ".text$b",
+            IMAGE_SCN_CNT_CODE | IMAGE_SCN_MEM_EXECUTE | IMAGE_SCN_MEM_READ,
+        ),
+        (
+            ".text$c",
+            IMAGE_SCN_CNT_CODE | IMAGE_SCN_MEM_EXECUTE | IMAGE_SCN_MEM_READ,
+        ),
+        (
+            ".data$a",
+            IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_READ | IMAGE_SCN_MEM_WRITE,
+        ),
+        (
+            ".data$b",
+            IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_READ | IMAGE_SCN_MEM_WRITE,
+        ),
+        (
+            ".data$c",
+            IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_READ | IMAGE_SCN_MEM_WRITE,
+        ),
+    ];
+
+    for &(test_name, test_characteristics) in test_sections {
+        let section = coff
+            .section_by_name(test_name)
+            .unwrap_or_else(|| panic!("Could not find section {test_name}"));
+
+        let characteristics = section
+            .coff_section()
+            .characteristics
+            .get(object::LittleEndian);
+
+        assert!(
+            characteristics & test_characteristics == test_characteristics,
+            "{test_name} section has invalid characteristics. characteristics = {characteristics:#x?}, test_characteristics = {test_characteristics:#x?}, contained = {:#x?}",
+            characteristics & test_characteristics
+        );
+    }
 }

--- a/tests/misc/no_merge_groups.yaml
+++ b/tests/misc/no_merge_groups.yaml
@@ -1,0 +1,227 @@
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ IMAGE_FILE_RELOCS_STRIPPED ]
+sections:
+  - Name:            .text$a
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment:       8
+    SectionData:     0000000000000000
+    SizeOfRawData:   8
+  - Name:            .text$b
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment:       8
+    SectionData:     0000000000000000
+    SizeOfRawData:   8
+  - Name:            .text$c
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment:       8
+    SectionData:     0000000000000000
+    SizeOfRawData:   8
+  - Name:            .data$a
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ, IMAGE_SCN_MEM_WRITE ]
+    Alignment:       8
+    SectionData:     0000000000000000
+    SizeOfRawData:   8
+  - Name:            .data$b
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ, IMAGE_SCN_MEM_WRITE ]
+    Alignment:       8
+    SectionData:     0000000000000000
+    SizeOfRawData:   8
+  - Name:            .data$c
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ, IMAGE_SCN_MEM_WRITE ]
+    Alignment:       8
+    SectionData:     0000000000000000
+    SizeOfRawData:   8
+symbols:
+  - Name:            .text$a
+    Value:           0
+    SectionNumber:   1
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          8
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          0
+
+  - Name:            .text$b
+    Value:           0
+    SectionNumber:   2
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          8
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          0
+
+  - Name:            .text$c
+    Value:           0
+    SectionNumber:   3
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          8
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          0
+
+  - Name:            .data$a
+    Value:           0
+    SectionNumber:   4
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          8
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          0
+
+  - Name:            .data$b
+    Value:           0
+    SectionNumber:   5
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          8
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          0
+
+  - Name:            .data$c
+    Value:           0
+    SectionNumber:   6
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          8
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          0
+
+--- !COFF
+header:
+  Machine: IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ IMAGE_FILE_RELOCS_STRIPPED ]
+sections:
+  - Name:            .text$a
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment:       8
+    SectionData:     0000000000000000
+    SizeOfRawData:   8
+  - Name:            .text$b
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment:       8
+    SectionData:     0000000000000000
+    SizeOfRawData:   8
+  - Name:            .text$c
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment:       8
+    SectionData:     0000000000000000
+    SizeOfRawData:   8
+  - Name:            .data$a
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ, IMAGE_SCN_MEM_WRITE ]
+    Alignment:       8
+    SectionData:     0000000000000000
+    SizeOfRawData:   8
+  - Name:            .data$b
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ, IMAGE_SCN_MEM_WRITE ]
+    Alignment:       8
+    SectionData:     0000000000000000
+    SizeOfRawData:   8
+  - Name:            .data$c
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ, IMAGE_SCN_MEM_WRITE ]
+    Alignment:       8
+    SectionData:     0000000000000000
+    SizeOfRawData:   8
+symbols:
+  - Name:            .text$a
+    Value:           0
+    SectionNumber:   1
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          8
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          0
+
+  - Name:            .text$b
+    Value:           0
+    SectionNumber:   2
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          8
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          0
+
+  - Name:            .text$c
+    Value:           0
+    SectionNumber:   3
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          8
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          0
+
+  - Name:            .data$a
+    Value:           0
+    SectionNumber:   4
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          8
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          0
+
+  - Name:            .data$b
+    Value:           0
+    SectionNumber:   5
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          8
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          0
+
+  - Name:            .data$c
+    Value:           0
+    SectionNumber:   6
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          8
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          0

--- a/tests/utils/macros.rs
+++ b/tests/utils/macros.rs
@@ -45,6 +45,7 @@ macro_rules! setup_linker {
 
         boflink::linker::LinkerBuilder::new()
             .architecture($arch)
+            .merge_grouped_sections(true)
             .library_searcher(__searcher)
             .add_inputs(__input_coffs)
             .add_libraries(__input_libraries)


### PR DESCRIPTION
Includes program option to not merge grouped sections in the output BOF. This can be useful if needing to perform additional GC passes later.

Fixes #14.