### PR TITLE
C++ symbol name demangling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ members = [
   "xtask",
 ]
 
+exclude = [
+  "crates/undname/sys"
+]
+
 [package]
 name = "boflink"
 version = "0.3.1"
@@ -43,6 +47,9 @@ features = ["std", "color", "help", "suggestions", "usage", "derive", "string", 
 version = "0.37.0"
 default-features = false
 features = ["archive", "coff", "write", "read"]
+
+[target.'cfg(windows)'.dependencies]
+undname = { path = "crates/undname" }
 
 [dev-dependencies]
 coffyaml = { path = "crates/coffyaml" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ anyhow = "1.0.92"
 argfile = "0.2.1"
 bitflags = "2.9.0"
 bumpalo = "3.17.0"
+cpp_demangle = "0.4.4"
 indexmap = "2.7.1"
 jamcrc = { path = "crates/jamcrc" }
 log = { version = "0.4.26", features = ["std"] }

--- a/crates/undname/Cargo.toml
+++ b/crates/undname/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "undname"
+version = "0.1.0"
+authors = ["Matt Ehrnschwender <matthewe2020@gmail.com>"]
+edition = "2024"
+description = "Wrapper around undname for demangling Microsoft C++ mangled symbols."
+readme = "README.md"
+homepage = "https://github.com/MEhrn00/boflink/tree/main/crates/undname"
+repository = "https://github.com/MEhrn00/boflink"
+publish = false
+
+[dependencies]
+bitflags = "2.9.1"
+undname-sys = { path = "sys" }
+thiserror = "2.0.12"
+
+[features]
+sys = []

--- a/crates/undname/README.md
+++ b/crates/undname/README.md
@@ -1,0 +1,2 @@
+# undname
+Wrapper around undname for demangling Microsoft C++ mangled symbols.

--- a/crates/undname/src/error.rs
+++ b/crates/undname/src/error.rs
@@ -1,0 +1,11 @@
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("mangled string contains an interior nul byte")]
+    MangledInteriorNul { position: usize },
+
+    #[error("demangled string is invalid UTF-8 {0}")]
+    Utf8(std::str::Utf8Error),
+
+    #[error("FFI returned NULL")]
+    FFINull,
+}

--- a/crates/undname/src/lib.rs
+++ b/crates/undname/src/lib.rs
@@ -1,0 +1,266 @@
+use std::ffi::{CStr, CString, FromBytesWithNulError};
+
+#[cfg(feature = "sys")]
+pub use undname_sys as sys;
+
+mod error;
+mod memproxy;
+
+pub use error::Error;
+
+/// Mask for passing the undname flags to [`undname_sys::__unDNameEx`].
+///
+/// undname.exe will unset bit 15 when calling `__unDNameEx`.
+const UNDNAME_FLAGS_MASK: u32 = !(1 << 14);
+
+/// Flags for customizing symbol demangling.
+///
+/// Constants are not fully documented in the Windows API docs https://learn.microsoft.com/en-us/windows/win32/api/dbghelp/nf-dbghelp-undecoratesymbolname.
+///
+/// Thankfully, MS decided to document them here https://github.com/microsoft/deoptexplorer-vscode/blob/9a6bc239bf88a6c26a52a517d41e1a00e1d96353/src/platforms/win32/api/dbghelp.ts#L529 :).
+///
+/// The UNDNAME_NO_MS_THISTYPE is wrong though and should be 0x60.
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UndnameFlags(u32);
+
+impl std::default::Default for UndnameFlags {
+    fn default() -> Self {
+        Self::Complete
+    }
+}
+
+bitflags::bitflags! {
+    impl UndnameFlags: u32 {
+        /// Enable full undecoration.
+        const Complete = undname_sys::UNDNAME_COMPLETE;
+
+        /// Remove leading underscores from Microsoft keywords.
+        const NoLeadingUnderscores = 0x0001;
+
+        /// Disable expansion of Microsoft keywords.
+        const NoMsKeywords = undname_sys::UNDNAME_NO_MS_KEYWORDS;
+
+        /// Disable expansion of return types for primary declarations.
+        const NoFunctionReturns = undname_sys::UNDNAME_NO_FUNCTION_RETURNS;
+
+        /// Disable expansion of the declaration model.
+        const NoAllocationModel = undname_sys::UNDNAME_NO_ALLOCATION_MODEL;
+
+        /// Disable expansion of the declaration language specifier.
+        const NoAllocationLanguage = undname_sys::UNDNAME_NO_ALLOCATION_LANGUAGE;
+
+        /// Disable all modifiers on the 'this' type.
+        const NoThistype = undname_sys::UNDNAME_NO_THISTYPE;
+
+        /// Disable expansion of access specifiers for members.
+        const NoAccessSpecifiers = undname_sys::UNDNAME_NO_ACCESS_SPECIFIERS;
+
+        /// Disable expansion of throw-signatures for functions and pointers to functions.
+        const NoThrowSignatures = undname_sys::UNDNAME_NO_THROW_SIGNATURES;
+
+        /// Disable expansion of the static or virtual attribute of members.
+        const NoMemberType = undname_sys::UNDNAME_NO_MEMBER_TYPE;
+
+        /// Disable expansion of the Microsoft model for user-defined type returns.
+        const NoReturnUdtModel = undname_sys::UNDNAME_NO_RETURN_UDT_MODEL;
+
+        /// Undecorate 32-bit decorated names.
+        const ThirtyTwoBitDecode = undname_sys::UNDNAME_32_BIT_DECODE;
+
+        /// Undecorate only the name for primary declaration. Returns [scope::]name. Does expand template parameters.
+        const NameOnly = undname_sys::UNDNAME_NAME_ONLY;
+
+        /// Do not undecorate function arguments.
+        const NoArguments = undname_sys::UNDNAME_NO_ARGUMENTS;
+
+        /// Disable enum/class/struct/union prefix.
+        const NoTypePrefix = 0x8000;
+
+        /// Disable expansion of __ptr64 keyword.
+        const NoPtr64Expansion = 0x20000;
+    }
+}
+
+/// Demangle the specified mangled symbol.
+pub fn undname(mangled: impl AsRef<str>, flags: UndnameFlags) -> Result<String, Error> {
+    match std::ffi::CStr::from_bytes_with_nul(mangled.as_ref().as_bytes()) {
+        Ok(mangled) => undname_cstr(mangled, flags),
+        Err(FromBytesWithNulError::NotNulTerminated) => {
+            let mangled = CString::new(mangled.as_ref().as_bytes()).map_err(|e| {
+                Error::MangledInteriorNul {
+                    position: e.nul_position(),
+                }
+            })?;
+
+            undname_cstr(mangled, flags)
+        }
+        Err(FromBytesWithNulError::InteriorNul { position }) => {
+            Err(Error::MangledInteriorNul { position })
+        }
+    }
+    .and_then(|demangled| {
+        demangled
+            .into_string()
+            .map_err(|e| Error::Utf8(e.utf8_error()))
+    })
+}
+
+/// Demangle the specified mangled symbol.
+pub fn undname_cstr(mangled: impl AsRef<CStr>, flags: UndnameFlags) -> Result<CString, Error> {
+    let demangled_ptr = unsafe {
+        undname_sys::__unDNameEx(
+            std::ptr::null_mut(),
+            mangled.as_ref().as_ptr(),
+            0,
+            memproxy::memget_callback,
+            memproxy::memfree_callback,
+            std::ptr::null(),
+            flags.bits() & UNDNAME_FLAGS_MASK,
+        )
+    };
+
+    if demangled_ptr.is_null() {
+        return Err(Error::FFINull);
+    }
+
+    let demangled_cstr = unsafe { CStr::from_ptr(demangled_ptr) };
+    let demangled = demangled_cstr.to_owned();
+
+    unsafe {
+        memproxy::memfree_callback(demangled_ptr.cast());
+    }
+
+    Ok(demangled)
+}
+
+#[cfg(windows)]
+#[cfg(test)]
+mod tests_windows {
+    use std::ffi::CStr;
+
+    use super::{UndnameFlags, undname, undname_cstr};
+
+    #[test]
+    fn demangle_cstr() {
+        const TESTS: &[(&CStr, &str)] = &[
+            (c"??$f@W4Bar@@@@YAXH@Z", "void __cdecl f<enum Bar>(int)"),
+            (
+                c"??$foo@H$$A6AXN@ZH@@YAXXZ",
+                "void __cdecl foo<int,void __cdecl(double),int>(void)",
+            ),
+            (
+                c"??6@YA?AUA@@AEBU0@0@Z",
+                "struct A __cdecl operator<<(struct A const &,struct A const &)",
+            ),
+            (
+                c"??H@YA?AUA@@AEAU0@0@Z",
+                "struct A __cdecl operator+(struct A &,struct A &)",
+            ),
+            (
+                c"??L@YA?AUA@@U0@0@Z",
+                "struct A __cdecl operator%(struct A,struct A)",
+            ),
+            (c"?asdf@@YAXW4Bar@@@Z", "void __cdecl asdf(enum Bar)"),
+            (
+                c"?bar@?$Foo@$$BY03H@@QEAAXXZ",
+                "public: void __cdecl Foo<int [4]>::bar(void)",
+            ),
+            (c"?f@@YAXH@Z", "void __cdecl f(int)"),
+            (c"?f@ns@@YAXXZ", "void __cdecl ns::f(void)"),
+        ];
+
+        for (symbol, expected) in TESTS {
+            let result = undname_cstr(symbol, UndnameFlags::NoPtr64Expansion)
+                .unwrap_or_else(|e| panic!("Could not demangle {symbol:?}: {e}"));
+
+            let result_str = result.to_str().expect("Could not convert result to UTF8");
+            assert_eq!(
+                result_str, *expected,
+                "demangled string {symbol:?} does not match {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn demangle_str_null() {
+        const TESTS: &[(&str, &str)] = &[
+            ("??$f@W4Bar@@@@YAXH@Z\0", "void __cdecl f<enum Bar>(int)"),
+            (
+                "??$foo@H$$A6AXN@ZH@@YAXXZ\0",
+                "void __cdecl foo<int,void __cdecl(double),int>(void)",
+            ),
+            (
+                "??6@YA?AUA@@AEBU0@0@Z\0",
+                "struct A __cdecl operator<<(struct A const &,struct A const &)",
+            ),
+            (
+                "??H@YA?AUA@@AEAU0@0@Z\0",
+                "struct A __cdecl operator+(struct A &,struct A &)",
+            ),
+            (
+                "??L@YA?AUA@@U0@0@Z\0",
+                "struct A __cdecl operator%(struct A,struct A)",
+            ),
+            ("?asdf@@YAXW4Bar@@@Z\0", "void __cdecl asdf(enum Bar)"),
+            (
+                "?bar@?$Foo@$$BY03H@@QEAAXXZ\0",
+                "public: void __cdecl Foo<int [4]>::bar(void)",
+            ),
+            ("?f@@YAXH@Z\0", "void __cdecl f(int)"),
+            ("?f@ns@@YAXXZ\0", "void __cdecl ns::f(void)"),
+        ];
+
+        for (symbol, expected) in TESTS {
+            let result = undname(symbol, UndnameFlags::NoPtr64Expansion)
+                .unwrap_or_else(|e| panic!("Could not demangle {symbol:?}: {e}"));
+
+            assert_eq!(
+                result.as_str(),
+                *expected,
+                "demangled string {symbol:?} does not match {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn demangle_str_nonnull() {
+        const TESTS: &[(&str, &str)] = &[
+            ("??$f@W4Bar@@@@YAXH@Z", "void __cdecl f<enum Bar>(int)"),
+            (
+                "??$foo@H$$A6AXN@ZH@@YAXXZ",
+                "void __cdecl foo<int,void __cdecl(double),int>(void)",
+            ),
+            (
+                "??6@YA?AUA@@AEBU0@0@Z",
+                "struct A __cdecl operator<<(struct A const &,struct A const &)",
+            ),
+            (
+                "??H@YA?AUA@@AEAU0@0@Z",
+                "struct A __cdecl operator+(struct A &,struct A &)",
+            ),
+            (
+                "??L@YA?AUA@@U0@0@Z",
+                "struct A __cdecl operator%(struct A,struct A)",
+            ),
+            ("?asdf@@YAXW4Bar@@@Z", "void __cdecl asdf(enum Bar)"),
+            (
+                "?bar@?$Foo@$$BY03H@@QEAAXXZ",
+                "public: void __cdecl Foo<int [4]>::bar(void)",
+            ),
+            ("?f@@YAXH@Z", "void __cdecl f(int)"),
+            ("?f@ns@@YAXXZ", "void __cdecl ns::f(void)"),
+        ];
+
+        for (symbol, expected) in TESTS {
+            let result = undname(symbol, UndnameFlags::NoPtr64Expansion)
+                .unwrap_or_else(|e| panic!("Could not demangle {symbol:?}: {e}"));
+
+            assert_eq!(
+                result.as_str(),
+                *expected,
+                "demangled string {symbol:?} does not match {expected}"
+            );
+        }
+    }
+}

--- a/crates/undname/src/memproxy.rs
+++ b/crates/undname/src/memproxy.rs
@@ -1,0 +1,166 @@
+//! Proxy functions for [`undname_sys::__unDName`] mem callbacks.
+
+use std::{alloc::Layout, mem::MaybeUninit};
+
+/// A memory chunk for memget/memfree operations
+#[repr(C)]
+struct MemChunk<T: ?Sized> {
+    /// The total size of this chunk allocation.
+    size: usize,
+
+    /// The chunk data.
+    data: T,
+}
+
+/// Callback function for [`undname_sys::__unDName`] memget.
+///
+/// # Safety
+/// This should NEVER be called outside of the
+/// [`undname_sys::__unDName`] context.
+pub unsafe extern "C" fn memget_callback(size: usize) -> *mut std::ffi::c_void {
+    let mut alloc_size = size;
+    if alloc_size == 0 {
+        alloc_size = 1;
+    }
+
+    let size_needed = std::mem::size_of::<MemChunk<()>>() + alloc_size;
+    if isize::try_from(size_needed).is_err() {
+        // SAFETY: This layout is only used for propogating the layout error.
+        std::alloc::handle_alloc_error(unsafe {
+            Layout::from_size_align_unchecked(
+                isize::MAX as usize,
+                std::mem::align_of::<MemChunk<()>>(),
+            )
+        });
+    }
+
+    // Get the layout needed for the chunk
+    // SAFETY: `_unchecked` is used for performance.
+    // - The size needed is checked if it will overflow an isize.
+    // - The alignment should always be correct since it is from the compiler.
+    let chunk_layout = unsafe {
+        Layout::from_size_align_unchecked(size_needed, std::mem::align_of::<MemChunk<()>>())
+    };
+
+    // Pad alignment
+    let chunk_layout = chunk_layout.pad_to_align();
+
+    // SAFETY: Requires check for NULL pointer on failed allocation.
+    let chunk_alc = unsafe { std::alloc::alloc(chunk_layout) };
+    if chunk_alc.is_null() {
+        std::alloc::handle_alloc_error(chunk_layout);
+    }
+
+    let chunk_ptr: *mut MemChunk<[MaybeUninit<u8>; 1]> = chunk_alc.cast();
+    // SAFETY: Pointer is non-NULL and properly aligned.
+    unsafe { (*chunk_ptr).size = chunk_layout.size() };
+
+    // SAFETY:
+    // - chunk_ptr is non-NULL.
+    // - Access to the data field is properly aligned
+    // - data field is uninitialized and should not be dereferenced!!!
+    let data_ptr = unsafe { std::ptr::addr_of_mut!((*chunk_ptr).data) };
+
+    data_ptr.cast()
+}
+
+/// Callback function for [`undname_sys::__unDName`]` memfree.
+///
+/// # Safety
+/// This function should NEVER be called outside of the
+/// [`undname_sys::__unDName`] context.
+pub unsafe extern "C" fn memfree_callback(ptr: *mut std::ffi::c_void) {
+    if ptr.is_null() {
+        return;
+    }
+
+    let data_ptr: *mut [MaybeUninit<u8>; 1] = ptr.cast();
+
+    // SAFETY: This is wildly unsafe lmao.
+    let chunk_ptr: *mut MemChunk<[MaybeUninit<u8>; 1]> = unsafe {
+        data_ptr
+            .byte_sub(std::mem::offset_of!(MemChunk<()>, data))
+            .cast()
+    };
+
+    if chunk_ptr.is_null() || !chunk_ptr.is_aligned() {
+        panic!("Called memfree_callback on invalid pointer");
+    }
+
+    // SAFETY: chunk_ptr is not NULL and properly aligned to read from.
+    let chunk_size = unsafe { (*chunk_ptr).size };
+
+    if isize::try_from(chunk_size).is_err() {
+        panic!("memfree_callback chunk size overflows an isize");
+    }
+
+    // SAFETY:
+    // - The chunk size has been checked if it will overflow an isize.
+    // - The alignment should always be correct since it is from the compiler.
+    let chunk_layout = unsafe {
+        Layout::from_size_align_unchecked(chunk_size, std::mem::size_of::<MemChunk<()>>())
+    };
+
+    // SAFETY: Assuming that this function was called correctly, the dealloc
+    // here should be fine. If it was not called correctly, then RIP o7
+    unsafe { std::alloc::dealloc(chunk_ptr.cast(), chunk_layout) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{memfree_callback, memget_callback};
+
+    fn run_allocation_tests(alloc_range: impl Iterator<Item = usize>) {
+        for alloc_size in alloc_range {
+            let ptr = unsafe { memget_callback(alloc_size) };
+
+            assert!(
+                !ptr.is_null(),
+                "memget_callback for {alloc_size} returned a NULL pointer"
+            );
+
+            unsafe {
+                memfree_callback(ptr);
+            }
+        }
+    }
+
+    #[test]
+    fn alloc_zero() {
+        let ptr = unsafe { memget_callback(0) };
+
+        assert!(
+            !ptr.is_null(),
+            "memget_callback allocation for size 0 should return a non-NULL pointer"
+        );
+
+        unsafe {
+            memfree_callback(ptr);
+        }
+    }
+
+    #[test]
+    fn small_allocations() {
+        run_allocation_tests((1..=0x250).step_by(10));
+    }
+
+    #[test]
+    fn medium_allocations() {
+        run_allocation_tests((0x250..=0x500).step_by(10));
+    }
+
+    #[test]
+    fn large_allocations() {
+        run_allocation_tests((0x500..=0x900).step_by(10));
+    }
+
+    #[test]
+    fn page_boundaries() {
+        run_allocation_tests(
+            [
+                0xfff, 0x1000, 0x1001, 0x1fff, 0x2000, 0x2001, 0x2fff, 0x3000, 0x3001,
+            ]
+            .into_iter(),
+        );
+    }
+}

--- a/crates/undname/sys/Cargo.toml
+++ b/crates/undname/sys/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "undname-sys"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+windows-link = "0.1.3"
+windows-sys = { version = "0.60.2", features = [
+  "Win32_System_Diagnostics_Debug"
+] }

--- a/crates/undname/sys/src/lib.rs
+++ b/crates/undname/sys/src/lib.rs
@@ -1,0 +1,15 @@
+#![allow(non_camel_case_types)]
+
+pub type malloc_func_t = unsafe extern "C" fn(usize) -> *mut std::ffi::c_void;
+pub type free_func_t = unsafe extern "C" fn(*mut std::ffi::c_void);
+
+windows_link::link!("vcruntime140.dll" "C" fn __unDNameEx(buffer: *mut std::ffi::c_char, mangled: *const std::ffi::c_char, buflen: std::ffi::c_int, memget: malloc_func_t, memfree: free_func_t, unknown: *const std::ffi::c_void, flags: std::ffi::c_uint) -> *mut std::ffi::c_char);
+
+pub use windows_sys::Win32::System::Diagnostics::Debug::{
+    UNDNAME_32_BIT_DECODE, UNDNAME_COMPLETE, UNDNAME_NAME_ONLY, UNDNAME_NO_ACCESS_SPECIFIERS,
+    UNDNAME_NO_ALLOCATION_LANGUAGE, UNDNAME_NO_ALLOCATION_MODEL, UNDNAME_NO_ARGUMENTS,
+    UNDNAME_NO_CV_THISTYPE, UNDNAME_NO_FUNCTION_RETURNS, UNDNAME_NO_LEADING_UNDERSCORES,
+    UNDNAME_NO_MEMBER_TYPE, UNDNAME_NO_MS_KEYWORDS, UNDNAME_NO_MS_THISTYPE,
+    UNDNAME_NO_RETURN_UDT_MODEL, UNDNAME_NO_SPECIAL_SYMS, UNDNAME_NO_THISTYPE,
+    UNDNAME_NO_THROW_SIGNATURES,
+};

--- a/src/graph/built.rs
+++ b/src/graph/built.rs
@@ -7,7 +7,10 @@ use indexmap::IndexMap;
 use log::{debug, warn};
 use object::pe::{IMAGE_REL_AMD64_REL32, IMAGE_REL_I386_DIR32};
 
-use crate::linker::{LinkerTargetArch, error::LinkError};
+use crate::{
+    graph::node::SymbolName,
+    linker::{LinkerTargetArch, error::LinkError},
+};
 
 use super::{
     edge::{ComdatSelection, DefinitionEdgeWeight, Edge, RelocationEdgeWeight},
@@ -399,9 +402,12 @@ impl<'arena, 'data> BuiltLinkGraph<'arena, 'data> {
                 // Add a new import symbol for the thunk definition
                 let thunk_import_symbol = self.arena.alloc_with(|| {
                     SymbolNode::new(
-                        &*self
-                            .arena
-                            .alloc_str(&format!("__imp_{}", import_name.as_str())),
+                        SymbolName::new(
+                            &*self
+                                .arena
+                                .alloc_str(&format!("__imp_{}", import_name.as_str())),
+                            self.machine == LinkerTargetArch::I386,
+                        ),
                         SymbolNodeStorageClass::External,
                         false,
                         SymbolNodeType::Value(0),

--- a/src/graph/edge.rs
+++ b/src/graph/edge.rs
@@ -394,8 +394,8 @@ impl<'data> ImportEdgeWeight<'data> {
     }
 
     #[inline]
-    pub fn import_name(&self) -> SymbolName<'data> {
-        self.import_name
+    pub fn import_name(&self) -> &SymbolName<'data> {
+        &self.import_name
     }
 }
 

--- a/src/graph/node/symbol.rs
+++ b/src/graph/node/symbol.rs
@@ -371,6 +371,13 @@ impl std::fmt::Display for SymbolNameDemangler<'_, '_> {
             }
         }
 
+        if (self.0.is_i386() && symbol_name.starts_with("__Z")) || symbol_name.starts_with("_Z") {
+            if let Ok(demangled) = cpp_demangle::Symbol::new(symbol_name) {
+                write!(f, "{demangled}")?;
+                return Ok(());
+            }
+        }
+
         write!(f, "{symbol_name}")
     }
 }


### PR DESCRIPTION
Adds support for demangling C++ symbols in diagnostic output messages.

This includes support for demangling both [MSVC Decorated names](https://learn.microsoft.com/en-us/cpp/build/reference/decorated-names?view=msvc-170&redirectedfrom=MSDN) and [Itanium C++ ABI](https://itanium-cxx-abi.github.io/cxx-abi/abi.html) symbols.

MSVC decorated name demangling only works on Windows.