### PR TITLE
Fix MinGW legacy import library DATA import parsing

### DIFF
--- a/src/linkobject/archive/error.rs
+++ b/src/linkobject/archive/error.rs
@@ -116,6 +116,9 @@ pub enum LegacyImportSymbolMemberParseError {
     #[error("import lookup table name section is malformed")]
     IltNameMalformed,
 
+    #[error("import address table symbol is missing")]
+    MissingIatSymbol,
+
     #[error("name string from the import lookup table name table could not be parsed: {0}")]
     ImportName(std::str::Utf8Error),
 


### PR DESCRIPTION
Changes parsing strategy for legacy import library COFF symbol members to parse DATA imports

Fixes: #21
Resolves: #22