### PR TITLE
Add '--warn-unresolved-symbols'

### DIFF
--- a/src/bin/boflink/arguments.rs
+++ b/src/bin/boflink/arguments.rs
@@ -90,6 +90,10 @@ pub struct CliOptionArgs {
     #[arg(long)]
     pub print_gc_sections: bool,
 
+    /// Report unresolved symbols as warnings
+    #[arg(long)]
+    pub warn_unresolved_symbols: bool,
+
     /// Query x86_64-w64-mingw32-gcc for its list of library search paths
     #[arg(long, conflicts_with_all = ["mingw32", "ucrt64", "ucrt32"])]
     pub mingw64: bool,

--- a/src/bin/boflink/main.rs
+++ b/src/bin/boflink/main.rs
@@ -136,7 +136,8 @@ fn run_linker(args: &mut ParsedCliArgs) -> anyhow::Result<()> {
         .gc_sections(args.options.gc_sections)
         .print_gc_sections(args.options.print_gc_sections)
         .add_gc_keep_symbols(std::mem::take(&mut args.options.keep_symbol))
-        .merge_grouped_sections(args.options.merge_groups);
+        .merge_grouped_sections(args.options.merge_groups)
+        .warn_unresolved(args.options.warn_unresolved_symbols);
 
     let linker = if let Some(target_arch) = args.options.machine.take() {
         linker.architecture(target_arch.into())

--- a/src/graph/edge.rs
+++ b/src/graph/edge.rs
@@ -2,7 +2,7 @@ use std::{cell::Cell, marker::PhantomData};
 
 use crate::graph::node::{LibraryNode, SectionNode, SymbolNode};
 
-use super::node::SymbolName;
+use super::node::{SymbolName, SymbolReferencesIter};
 
 use __private::SealedTrait;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
@@ -164,6 +164,13 @@ where
 pub struct EdgeListIter<'arena, E: EdgeListEntry<'arena, T>, T: EdgeListTraversal>(
     (Option<&'arena E>, PhantomData<T>),
 );
+
+impl<'arena, 'data> EdgeListIter<'arena, RelocationEdge<'arena, 'data>, IncomingEdges> {
+    /// Adapts this iterator to return symbol references
+    pub fn symbols(self) -> SymbolReferencesIter<'arena, 'data> {
+        SymbolReferencesIter::new(self)
+    }
+}
 
 impl<'arena, E: EdgeListEntry<'arena, T>, T: EdgeListTraversal> Clone
     for EdgeListIter<'arena, E, T>

--- a/src/linker/builder.rs
+++ b/src/linker/builder.rs
@@ -61,6 +61,9 @@ pub struct LinkerBuilder<L: LibraryFind + 'static> {
 
     /// Print sections discarded during GC sections.
     pub(super) print_gc_sections: bool,
+
+    /// Report unresolved symbols as warnings.
+    pub(super) warn_unresolved: bool,
 }
 
 impl<L: LibraryFind + 'static> LinkerBuilder<L> {
@@ -78,6 +81,7 @@ impl<L: LibraryFind + 'static> LinkerBuilder<L> {
             gc_sections: false,
             gc_keep_symbols: Default::default(),
             print_gc_sections: false,
+            warn_unresolved: false,
         }
     }
 
@@ -135,6 +139,12 @@ impl<L: LibraryFind + 'static> LinkerBuilder<L> {
     /// Print sections discarded during GC sections.
     pub fn print_gc_sections(mut self, val: bool) -> Self {
         self.print_gc_sections = val;
+        self
+    }
+
+    /// Report unresolved symbols as warnings.
+    pub fn warn_unresolved(mut self, val: bool) -> Self {
+        self.warn_unresolved = val;
         self
     }
 


### PR DESCRIPTION
Adds '--warn-unresolved-symbols' option for returning warnings on unresolved symbols instead of errors.

Resolves: #15
